### PR TITLE
Allow importing ghosts through URL

### DIFF
--- a/ghostmanager/Scripts/ghost_handling.js
+++ b/ghostmanager/Scripts/ghost_handling.js
@@ -242,18 +242,13 @@ function parseURL(ghosturl) {
         newurl = ghosturl;
     }
 
-    //need cors proxy
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', newurl, true);
+    xhr.open('GET', `http://cors-anywhere.herokuapp.com/${newurl}`, true);
     xhr.responseType = 'arraybuffer';
     xhr.overrideMimeType(Blob);
     xhr.onreadystatechange = function () {
         if (this.readyState===4 && this.status===200) {
-            read_rkg_files(new Blob([this.response],true));
-        }
-        else {
-            console.log('error');
-            //tell user invalid
+            read_rkg_files([new File([this.response],true)]);
         }
     }
     xhr.send();

--- a/ghostmanager/Scripts/ghost_handling.js
+++ b/ghostmanager/Scripts/ghost_handling.js
@@ -229,3 +229,32 @@ function import_ghosts(ghost_type) {
     }
     update_chosen_license(CURRENT_LICENSE, ghost_type);
 }
+
+function parseURL(ghosturl) {
+    var newurl;
+    if (ghosturl.includes("maschell.de") || ghosturl.includes("ninrankings.org")) {
+        newurl = ghosturl.replace("ghostviewer","download");
+    }
+    else if (ghosturl.includes("chadsoft.co.uk")) {
+        newurl = ghosturl.replace(".html",".rkg");
+    }
+    else {
+        newurl = ghosturl;
+    }
+
+    //need cors proxy
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', newurl, true);
+    xhr.responseType = 'arraybuffer';
+    xhr.overrideMimeType(Blob);
+    xhr.onreadystatechange = function () {
+        if (this.readyState===4 && this.status===200) {
+            read_rkg_files(new Blob([this.response],true));
+        }
+        else {
+            console.log('error');
+            //tell user invalid
+        }
+    }
+    xhr.send();
+}

--- a/ghostmanager/Scripts/startup.js
+++ b/ghostmanager/Scripts/startup.js
@@ -108,6 +108,22 @@ document.addEventListener("DOMContentLoaded", function() {
         }
     }
 
+    const urlButton = document.getElementById('url-button');
+    urlButton.onclick = () => {
+        if (!DOWNLOADING_GHOSTS) {
+            const active_tab = document.querySelector('#license li.is-active');
+            parseURL(document.getElementById("url-input").value);
+        }
+    }
+
+    //also submits url with enter key
+    const urlInput = document.getElementById('url-input');
+    urlInput.addEventListener("keyup",function(event) {
+        if (event.keyCode===13) {
+            urlButton.click();
+        }
+    });
+
     // drag&drop functionality
 
     var rksysDropArea = document.getElementById('rksys');

--- a/ghostmanager/index.html
+++ b/ghostmanager/index.html
@@ -125,6 +125,13 @@
                     </div>
                 </div>
             </div>
+            <!-- Not styled properly and remember to update howto -->
+            <div>
+                <input class="column input" type="text" id="url-input" placeholder="Input Ghost URL">
+                <button class="column button neutral has-text-weight-bold" id="url-button">
+                    Import
+                </button>
+            </div>
             <div class="columns">
                 <div class="column"></div>
                 <div class="column is-8" id="save-butt-col">

--- a/howto/ghostmanager.html
+++ b/howto/ghostmanager.html
@@ -45,7 +45,7 @@
         Importing ghosts
     </p>
     <p>
-        Press <span class="tag is-info is-light">Upload RKG</span> and select as many ghosts as you want. Alternatively, drag and drop the ghosts into the upload region.
+        Paste the URL of a Chadsoft page, ninrankings/maschell page, or a direct ghost link (e.g. Discord attachment) and click the <span class="tag is-info is-light">Import</span> button or press enter to import a ghost. If you would like to upload a ghost, press <span class="tag is-info is-light">Upload RKG</span> and select as many ghosts as you want. Alternatively, drag and drop the ghosts into the upload region.
         Select the license where you want your ghosts to be imported. You also have the option to choose whether the ghosts should be imported as pb's or downloaded ghosts.
         The following table shows the differences between these 2 types.
     </p>


### PR DESCRIPTION
**The new components haven't been styled properly yet**, but it otherwise appears functional. It takes a ghost link and detects whether it is from CTGP, maschell.de/ninranking.org, or a direct source and formats it correctly for download once the user presses enter or presses the button. It then treats the file the same way as an uploaded file and imports it to the ghostmanager. There is no longer a need to download ghosts, upload them, and then delete the ghosts (although that option remains). I've updated the howto page to reflect the update.

I plan to create this same functionality for the custom top 10.